### PR TITLE
Remove trailing slash

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
             <div class="column right">
                 <h1>nheko</h1>
 
-                <p>The motivation behind the project is to provide a native desktop app for <a href="https://matrix.org/" target="_blank">Matrix</a> that feels more like a mainstream chat app (<a href="https://element.io/features/" target="_blank">Element</a>, Telegram etc) and less like an IRC client.
+                <p>The motivation behind the project is to provide a native desktop app for <a href="https://matrix.org/" target="_blank">Matrix</a> that feels more like a mainstream chat app (<a href="https://element.io/features" target="_blank">Element</a>, Telegram etc) and less like an IRC client.
 </p>
 <br/>
 


### PR DESCRIPTION
This patch removes the trailing slash from the hyperlink to [feature's page on the element.io website](https://element.io/features). 

As it currently is, the trailing slash produces a 404 error.

What's currently there: 
![image](https://user-images.githubusercontent.com/39808659/105569474-d424b480-5d0f-11eb-8126-af0249467af8.png)

What should be there: 
![image](https://user-images.githubusercontent.com/39808659/105569483-e0a90d00-5d0f-11eb-91a1-3dddc62ee669.png)

