### PR TITLE
Add Chocolatey installation documentation

### DIFF
--- a/repositories/index.html
+++ b/repositories/index.html
@@ -77,7 +77,10 @@ sudo emerge -a nheko</pre>
 with macports :</h3>
 <pre>sudo port install nheko</pre>
 
-
+<h3>Windows
+with Chocolatey :</h3>
+<pre>choco install nheko-reborn</pre>
+    
 
                 
                     <div class="links">


### PR DESCRIPTION
Updated repositories documentation to include instructions on installing
Nheko using the Chocolatey package manager on Windows.