### PR TITLE
fix: Add OpenSUSE installation instructions

### DIFF
--- a/repositories/index.html
+++ b/repositories/index.html
@@ -59,6 +59,17 @@
 <pre>sudo dnf install nheko</pre>
 <br/>
 
+<h3>OpenSUSE</h3>
+<h4>Tumbleweed</h4>
+<pre>zypper ar https://download.opensuse.org/repositories/network:messaging:matrix/openSUSE_Tumbleweed/network:messaging:matrix.repo
+zypper ref
+zypper in nheko</pre>
+<h4>Leap</h4>
+<pre>zypper ar https://download.opensuse.org/repositories/network:messaging:matrix/15.5/network:messaging:matrix.repo
+zypper ref
+zypper in nheko</pre>
+<br />
+
 <h3>Gentoo Linux</h3>
 <pre>sudo eselect repository enable guru
 sudo emaint sync -r guru


### PR DESCRIPTION
This PR adds installation instructions for OpenSUSE (both the Tumbleweed rolling release and the Leap regular release).

https://software.opensuse.org/package/nheko