### PR TITLE
Remove Alpine's testing repo reference

### DIFF
--- a/repositories/index.html
+++ b/repositories/index.html
@@ -66,7 +66,6 @@ sudo emerge -a nheko</pre>
 <br/>
 
 <h3>Alpine Linux (and postmarketOS)</h3>
-<p class="notation">Make sure you have the testing repositories from edge enabled. Note that this is not needed on postmarketOS.</p>
 <pre>sudo apk add nheko</pre>
 <br/>
 


### PR DESCRIPTION
nheko was moved from Alpine's testing repository to the community repo 3 years ago. The community repository is generally enabled by default.

Ref: https://gitlab.alpinelinux.org/alpine/aports/-/commit/db927e4ed8760f933d4d04d29ac6998165338141